### PR TITLE
Reorder and categorize index

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,31 +9,35 @@ get fleshed out soon, but in the meantime there is a table of initial IPD
 
 | state     | IPD |
 | --------- | ------------------------------------------------------------- |
-| predraft  | [IPD 1 Virtual Environment for Jenkins Build and Test](./ipd/0001/README.md) |
-| published | [IPD 2 Running smatch for illumos builds](./ipd/0002/README.md) |
-| predraft  | [IPD 3 Link management improvements](./ipd/0003/README.md) |
-| draft     | [IPD 4 Manual Page Section Renumbering](./ipd/0004/README.md) |
-| published | [IPD 5 Rationalize SPARC platform support](./ipd/0005/README.md) |
-| draft     | [IPD 6 allocb(): The `pri` argument, and use of KM_NORMALPRI](./ipd/0006/README.md) |
-| published | [IPD 7 illumos GCC maintenance](./ipd/0007/README.md) |
-| draft     | [IPD 8 EOF NCA/NL7C](./ipd/0008/README.md) |
-| published | [IPD 9 PCI Alias Disambiguation](./ipd/0009/README.md) |
-| published | [IPD 10 full argv in ps](./ipd/0010/README.md) |
-| published | [IPD 11 NFS Server for Zones (NFS-Zone)](./ipd/0011/README.md) |
-| published | [IPD 12 /proc/_PID_/fdinfo/](./ipd/0012/README.md) |
-| published | [IPD 13 Safer DDI DMA Cookie Functions](./ipd/0013/README.md) |
-| predraft  | [IPD 14 illumos and Y2038](./ipd/0014/README.md) |
-| published | [IPD 15 bhyve integration/upstream](./ipd/0015/README.md) |
-| published | [IPD 16 EOF SunOS 4 binary compatibility](./ipd/0016/README.md) |
-| draft     | [IPD 17 SMF Runtime Directory Creation Support](./ipd/0017/README.md)
-| published | [IPD 18 overlay network integration/upstream](./ipd/0018/README.md)
-| published | [IPD 19 Sunset SPARC](./ipd/0019/README.md)
-| draft     | [IPD 20 Kernel Test Facility](./ipd/0020/README.adoc)
-| published | [IPD 21 PCI Platform Unification](./ipd/0021/README.md)
-| draft     | [IPD 22 Unsharing shared Libraries](./ipd/0022/README.md)
-| predraft  | [IPD 23 Xen and the Art of Operating System Maintenance: A Removal of a Platform](./ipd/0023/README.md)
 | predraft  | [IPD 24 Support for 64-bit ARM](./ipd/0024/README.md)
-=======
+| predraft  | [IPD 23 Xen and the Art of Operating System Maintenance: A Removal of a Platform](./ipd/0023/README.md)
+| draft     | [IPD 22 Unsharing shared Libraries](./ipd/0022/README.md)
+| published | [IPD 21 PCI Platform Unification](./ipd/0021/README.md)
+| draft     | [IPD 20 Kernel Test Facility](./ipd/0020/README.adoc)
+| published | [IPD 19 Sunset SPARC](./ipd/0019/README.md)
+| published | [IPD 18 overlay network integration/upstream](./ipd/0018/README.md)
+| draft     | [IPD 17 SMF Runtime Directory Creation Support](./ipd/0017/README.md)
+| predraft  | [IPD 14 illumos and Y2038](./ipd/0014/README.md) |
+| published | [IPD 10 full argv in ps](./ipd/0010/README.md) |
+| draft     | [IPD 8 EOF NCA/NL7C](./ipd/0008/README.md) |
+| published | [IPD 7 illumos GCC maintenance](./ipd/0007/README.md) |
+| draft     | [IPD 6 allocb(): The `pri` argument, and use of KM\_NORMALPRI](./ipd/0006/README.md) |
+| draft     | [IPD 4 Manual Page Section Renumbering](./ipd/0004/README.md) |
+| predraft  | [IPD 3 Link management improvements](./ipd/0003/README.md) |
+| predraft  | [IPD 1 Virtual Environment for Jenkins Build and Test](./ipd/0001/README.md) |
+
+### Completed/Inactive
+
+| IPD |
+| ------------------------------------------------------------- |
+| [IPD 16 EOF SunOS 4 binary compatibility](./ipd/0016/README.md) |
+| [IPD 15 bhyve integration/upstream](./ipd/0015/README.md) |
+| [IPD 13 Safer DDI DMA Cookie Functions](./ipd/0013/README.md) |
+| [IPD 12 /proc/\<PID\>/fdinfo/](./ipd/0012/README.md) |
+| [IPD 11 NFS Server for Zones (NFS-Zone)](./ipd/0011/README.md) |
+| [IPD 9 PCI Alias Disambiguation](./ipd/0009/README.md) |
+| [IPD 2 Running smatch for illumos builds](./ipd/0002/README.md) |
+| [IPD 5 Rationalize SPARC platform support](./ipd/0005/README.md) |
 
 ## Contributing
 


### PR DESCRIPTION
This moves IPDs which we know are complete or otherwise inactive to a separate section.  In addition to that, it reverse the ordering to newest-first.